### PR TITLE
Track inserts in Postgres databases

### DIFF
--- a/tests/lib/Phabric/Datasource/Doctrine.php
+++ b/tests/lib/Phabric/Datasource/Doctrine.php
@@ -72,6 +72,20 @@ class DoctrineTest extends \PHPUnit_Framework_TestCase {
         
         $this->assertEquals($input, $obj->getMappings());
     }
+
+    public function testConstructorInitMappingsIncludingOptionalSequence()
+    {
+        $input = array(
+            'event' => array(
+                'tableName' => 't_event',
+                'nameCol' => 'name',
+                'primaryKey' => 'id',
+                'sequence' => 't_event_id_seq'),
+        );
+
+        $obj = new Doctrine($this->mockedConnection, $input);
+        $this->assertEquals($input, $obj->getMappings());
+    }
     
     public function testGetMappingAfterAdd()
     {
@@ -87,7 +101,7 @@ class DoctrineTest extends \PHPUnit_Framework_TestCase {
         
         $this->assertEquals($expected, $this->object->getMappings());
     }
-    
+
     public function testGetMappingAfterSet()
     {
         $expected = array(
@@ -102,7 +116,7 @@ class DoctrineTest extends \PHPUnit_Framework_TestCase {
         
         $this->assertEquals($expected, $this->object->getMappings());
     }
-    
+
     public function testSetTableMappingsOvveridesExistingMappings()
     {
         
@@ -120,7 +134,7 @@ class DoctrineTest extends \PHPUnit_Framework_TestCase {
         
         $this->assertEquals($expected, $this->object->getMappings());
     }
-    
+
     public function testAddMappingsAppendsNotOverrides()
     {
         $this->object->addTableMapping('event', 't_event', 'id', 'name');
@@ -163,11 +177,41 @@ class DoctrineTest extends \PHPUnit_Framework_TestCase {
         
         $this->mockedConnection
                 ->shouldReceive('lastInsertId')
-                ->withNoArgs()
+                ->with(null)
                 ->andReturn(12);
         
         // Set the table mapping
         $this->object->addTableMapping('event', 't_event', 'id', 'name');
+        
+        
+        $this->assertEquals(12, $this->object->insert($mEntity, $values));
+    }
+
+    public function testInsertWithSequence()
+    {
+        $mEntity = m::mock('\Phabric\Entity');
+        
+        $mEntity->shouldReceive('getName')
+                ->withNoArgs()
+                ->andReturn('event');
+        
+        $values = array(
+                        'name' => 'PHPNW',
+                        'desc' => 'A Great Conf!',
+                        'date' => '2011-10-08 12:00:00');
+             
+        $this->mockedConnection
+              ->shouldReceive('insert')
+              ->with('t_event', $values)
+              ->andReturn(12);
+        
+        $this->mockedConnection
+                ->shouldReceive('lastInsertId')
+                ->with('t_event_id_seq')
+                ->andReturn(12);
+        
+        // Set the table mapping
+        $this->object->addTableMapping('event', 't_event', 'id', 'name', 't_event_id_seq');
         
         
         $this->assertEquals(12, $this->object->insert($mEntity, $values));
@@ -244,7 +288,7 @@ class DoctrineTest extends \PHPUnit_Framework_TestCase {
         
         $this->mockedConnection
                 ->shouldReceive('lastInsertId')
-                ->withNoArgs()
+                ->with(null)
                 ->andReturn(12);
         
         $this->mockedConnection
@@ -353,7 +397,7 @@ class DoctrineTest extends \PHPUnit_Framework_TestCase {
              
         $this->mockedConnection
                 ->shouldReceive('lastInsertId')
-                ->withNoArgs()
+                ->with(null)
                 ->andReturn(12);
         
         $this->mockedConnection


### PR DESCRIPTION
Hi Ben,

I noticed that `Phabric#reset()` was not deleting rows when using a Postgres database. This is because the underlying driver requires a sequence name to be passed to  `lastInsertId()`. If not suppled it returns false which screws up the internal resetMap.

This patch allows an optional **sequence** parameter to be added to a table mapping. For example:

```
Phabric:
  entities:
    users:
      tableName: 'users'
      primaryKey: 'id'
      nameCol: 'email'
      sequence: 'users_id_seq'
```

allows changes to be tracked in a table defined as

```
                      Table "public.users"
  Column  |  Type  |                     Modifiers                      
----------+--------+----------------------------------------------------
 id       | bigint | not null default nextval('users_id_seq'::regclass)
 email    | text   | not null
 password | text   | 
 name     | text   | not null
Indexes:
    "users_pkey" PRIMARY KEY, btree (id)
```

See: http://php.net/manual/en/pdo.lastinsertid.php for some more details.

Keeping this as a config value rather than trying to auto-generate a name seemed like the right approach as, even though Postgres defaults to `[table]_[column]_seq`, I think it's possible to have anything in there.

I also decided to have the internal table mappings omit the sequence key if none was supplied in order to minimise the number of changes required. An alternative would be to default this to a null entry. I'm happy to update if that style is preferred.

Cheers,
James
